### PR TITLE
updates option jsxBracketSameLine to bracketSameLine

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -5,7 +5,7 @@
   "singleQuote": true,
   "trailingComma": "all",
   "bracketSpacing": true,
-  "jsxBracketSameLine": false,
+  "bracketSameLine": false,
   "arrowParens": "avoid",
   "parser": "typescript"
 }


### PR DESCRIPTION
prettier 4.2 renames the jsxBracketSameLine option to bracketSameLine 
https://prettier.io/blog/2021/09/09/2.4.0.html